### PR TITLE
Fix validation for sendHabitNotification: fix 47

### DIFF
--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -11,6 +11,7 @@ import greencity.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -71,7 +72,7 @@ public class EmailController {
      * @author Taras Kavkalo
      */
     @PostMapping("/sendHabitNotification")
-    public ResponseEntity<Object> sendHabitNotification(@RequestBody SendHabitNotification sendHabitNotification) {
+    public ResponseEntity<Object> sendHabitNotification(@RequestBody @Valid SendHabitNotification sendHabitNotification) {
         emailService.sendHabitNotification(sendHabitNotification.getName(), sendHabitNotification.getEmail());
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/service-api/src/main/java/greencity/message/SendHabitNotification.java
+++ b/service-api/src/main/java/greencity/message/SendHabitNotification.java
@@ -1,6 +1,11 @@
 package greencity.message;
 
 import java.io.Serializable;
+
+import greencity.constant.ValidationConstants;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +19,13 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SendHabitNotification implements Serializable {
+    @Pattern(
+            regexp = ValidationConstants.USERNAME_REGEXP,
+            message = ValidationConstants.USERNAME_MESSAGE)
     private String name;
+
+    @Email(message = ValidationConstants.INVALID_EMAIL)
+    @NotBlank
     private String email;
 }
+


### PR DESCRIPTION
- Added validation to `SendHabitNotification` DTO.
- Applied `@Email`, `@NotBlank`, and `@Pattern` annotations to validate input fields.
- Ensured correct handling of invalid email and name formats.
- Now returns 400 Bad Request instead of 200 OK when input data is incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added input validation for habit notification requests, ensuring that names follow the required pattern and emails are properly formatted and not blank.

- **Bug Fixes**
  - Improved error handling for invalid input when sending habit notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->