### PR TITLE
[52] change security config for GET /user/email Notifications endpoin…

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -117,7 +117,7 @@ public class SecurityConfig {
                                 "/ownSecurity/restorePassword",
                                 "/googleSecurity",
                                 "/facebookSecurity/generateFacebookAuthorizeURL",
-                                "/facebookSecurity/facebook", "/user/emailNotifications",
+                                "/facebookSecurity/facebook",
                                 "/user/activatedUsersAmount",
                                 "/user/{userId}/habit/assign",
                                 "/token",


### PR DESCRIPTION
…t to get 401 response when user unauthorized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Access to the "/user/emailNotifications" endpoint now requires authentication; it is no longer available to unauthenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->