### PR TITLE
add 403 response code to updateUserManagement

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java~
+++ b/core/src/main/java/greencity/controller/UserController.java~
@@ -481,10 +481,7 @@ public class UserController {
      * @author Orest Mamchuk
      */
     @Operation(summary = "update via UserManagement")
-    @ApiResponses({
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
-    })
+    @ApiResponses({@ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED))
     @PutMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
     public void updateUserManagement(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to clarify that certain user management endpoints may return both "Unauthorized" (401) and "Forbidden" (403) responses. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->