### PR TITLE
fix: fix user profile picture deletion endpoint and security handling

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -312,7 +312,7 @@ public class UserController {
     })
     @PatchMapping(path = "/deleteProfilePicture")
     public ResponseEntity<HttpStatus> deleteUserProfilePicture(
-        @ApiIgnore @AuthenticationPrincipal Principal principal) {
+        @ApiIgnore Principal principal) {
         String email = principal.getName();
         userService.deleteUserProfilePicture(email);
         return ResponseEntity.status(HttpStatus.OK).build();


### PR DESCRIPTION
- Removed @AuthenticationPrincipal annotation from deleteUserProfilePicture method.
- Now using standard Principal injection to avoid NullPointerException when authorization is missing or invalid.
- Confirmed that:
    - 401 Unauthorized is returned if no valid token is present.
    - 200 OK is returned when authorized user successfully deletes profile picture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of user authentication in profile picture deletion. No visible changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->